### PR TITLE
Add Settings controller

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,13 @@
+class SettingsController < ApplicationController
+  # Profile things
+  def profile
+    @user = current_user
+    authorize @user, policy_class: SettingsPolicy
+  end
+
+  # Account settings
+  def account
+    @user = current_user
+    authorize @user, policy_class: SettingsPolicy
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -19,7 +19,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # GET /resource/edit
   def edit
     skip_authorization
-    super
+    redirect_to settings_account_path
   end
 
   # PUT /resource

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,22 @@ class UsersController < ApplicationController
     @purchased_releases = @user.releases
   end
 
+  def update
+    @user = User.find(params[:id])
+    authorize @user
+
+    respond_to do |format|
+      if @user.update(user_params)
+        format.html { redirect_to @user, success: "#{@user.username} was successfully updated." }
+      else
+        format.html do
+          flash.now[:error] = "Unable to update user."
+          render :edit
+        end
+      end
+    end
+  end
+
   def update_role
     @user = User.find(params[:id])
     role = params[:role].to_sym
@@ -32,5 +48,9 @@ class UsersController < ApplicationController
       flash.now[:error] = "Unable to save user."
       render :new
     end
+  end
+
+  def user_params
+    params.require(:user).permit(:bio)
   end
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,0 +1,14 @@
+module SettingsHelper
+  # These three helpers are used by devise's account forms.
+  def resource_name
+    :user
+  end
+
+  def resource
+    @resource ||= User.new
+  end
+
+  def devise_mapping
+    @devise_mapping ||= Devise.mappings[:user]
+  end
+end

--- a/app/policies/settings_policy.rb
+++ b/app/policies/settings_policy.rb
@@ -1,0 +1,16 @@
+class SettingsPolicy < ApplicationPolicy
+  attr_reader :current_user, :user
+
+  def initialize(current_user, user)
+    @current_user = current_user
+    @user = user
+  end
+
+  def profile?
+    current_user && @user == @current_user
+  end
+
+  def account?
+    current_user && @user == @current_user
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,6 +14,10 @@ class UserPolicy < ApplicationPolicy
     true
   end
 
+  def update?
+    current_user && @user = @current_user
+  end
+
   def update_role?
     current_user&.admin?
   end

--- a/app/views/devise/menu/_sign_up_items.html.erb
+++ b/app/views/devise/menu/_sign_up_items.html.erb
@@ -1,5 +1,5 @@
 <% if user_signed_in? %>
-  <%= link_to("Settings", edit_user_registration_path, class: "navbar-item") %>
+  <%= link_to("Settings", settings_path, class: "navbar-item") %>
 <% else %>
   <%= link_to('Sign up', new_user_registration_path, class: "navbar-item")  %>
 <% end %>

--- a/app/views/settings/_nav.html.erb
+++ b/app/views/settings/_nav.html.erb
@@ -1,0 +1,4 @@
+<ul>
+  <li><%= link_to 'Profile', settings_path %></li>
+  <li><%= link_to 'Account', settings_account_path %></li>
+</ul>

--- a/app/views/settings/account.html.erb
+++ b/app/views/settings/account.html.erb
@@ -1,4 +1,8 @@
-<h1 class="title">Edit <%= current_user.username %></h1>
+<% content_for :title, "Account Settings" %>
+
+<h1 class="title">Account Settings</h1>
+
+<%= render 'nav' %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= devise_error_messages! %>
@@ -15,7 +19,7 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :password, class: "label" %>
+    <%= f.label :password, 'New password', class: "label" %>
     <div class="control">
       <%= f.password_field :password, autocomplete: "new-password", class: "input" %>
       <% if @minimum_password_length %>
@@ -25,7 +29,7 @@
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation, class: "label" %>
+    <%= f.label :password_confirmation, 'New password confirmation', class: "label" %>
     <div class="control">
       <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input" %>
     </div>

--- a/app/views/settings/profile.html.erb
+++ b/app/views/settings/profile.html.erb
@@ -1,0 +1,5 @@
+<% content_for :title, "Profile Settings" %>
+
+<h1 class="title">Profile Settings</h1>
+
+<%= render 'nav' %>

--- a/app/views/settings/profile.html.erb
+++ b/app/views/settings/profile.html.erb
@@ -3,3 +3,16 @@
 <h1 class="title">Profile Settings</h1>
 
 <%= render 'nav' %>
+
+<%= form_for @user do |f| %>
+  <div class="field">
+    <%= f.label :bio, "Bio", class: "label" %>
+    <div class="control">
+      <%= f.text_area :bio, class: "textarea" %>
+    </div>
+  </div>
+
+  <div class="field">
+    <%= f.submit "Submit", class: "button is-primary" %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,4 +34,9 @@ Rails.application.routes.draw do
   resources :companies do
     get :search, on: :collection
   end
+
+  namespace :settings do
+    get :profile, as: '/', path: '/'
+    get :account
+  end
 end

--- a/spec/policies/settings_policy_spec.rb
+++ b/spec/policies/settings_policy_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe SettingsPolicy, type: :policy do
+  subject(:settings_policy) { described_class.new(current_user, current_user) }
+
+  describe 'A logged-in user' do
+    let(:current_user) { create(:user) }
+
+    it { should permit_actions([:profile, :account]) }
+  end
+
+  describe 'An anonymous user' do
+    let(:current_user) { nil }
+
+    it { should_not permit_actions([:profile, :account]) }
+  end
+end


### PR DESCRIPTION
Resolves #63.

This adds a Settings control so users can edit their bio or account information. It's also useful for adding 2FA and profile pictures later.

It also introduces a bug when there's an issue with the submitted form on the Account Settings page, where it redirects to `users/edit` which is unstyled since I deleted that custom view when moving the form to the settings controller.