### PR TITLE
Replace game to genre relationship.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Ensure that users can't have more than one copy of the same release in their library. ([#101])
+- Ensure that releases can't have more than one of the same genre. ([#102])
 
 ## v2019.1.26
 ### Added
@@ -103,3 +104,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#99]: https://github.com/connorshea/ContinueFromCheckpoint/pull/99
 [#100]: https://github.com/connorshea/ContinueFromCheckpoint/pull/100
 [#101]: https://github.com/connorshea/ContinueFromCheckpoint/pull/101
+[#102]: https://github.com/connorshea/ContinueFromCheckpoint/pull/102

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,7 +3,8 @@ class Game < ApplicationRecord
 
   has_many :releases
   has_many :platforms, through: :releases
-  has_and_belongs_to_many :genres
+  has_many :game_genres
+  has_many :genres, through: :game_genres, source: :genre
 
   validates :name,
     presence: true,

--- a/app/models/game_genre.rb
+++ b/app/models/game_genre.rb
@@ -1,0 +1,7 @@
+class GameGenre < ApplicationRecord
+  belongs_to :game
+  belongs_to :genre
+
+  validates :game_id,
+    uniqueness: { scope: :genre_id }
+end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,7 +1,8 @@
 class Genre < ApplicationRecord
   include PgSearch
 
-  has_and_belongs_to_many :games
+  has_many :game_genres
+  has_many :games, through: :game_genres, source: :game
 
   validates :name,
     presence: true,

--- a/db/migrate/20190127230914_drop_games_genres_table.rb
+++ b/db/migrate/20190127230914_drop_games_genres_table.rb
@@ -1,0 +1,9 @@
+class DropGamesGenresTable < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :games_genres
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20190127231411_create_game_genres.rb
+++ b/db/migrate/20190127231411_create_game_genres.rb
@@ -1,0 +1,15 @@
+class CreateGameGenres < ActiveRecord::Migration[5.2]
+  def change
+    create_table :game_genres do |t|
+      t.references :game, null: false
+      t.references :genre, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :game_genres, :games,
+      on_delete: :cascade
+    add_foreign_key :game_genres, :genres,
+      on_delete: :cascade
+  end
+end

--- a/db/migrate/20190127232524_add_unique_index_to_game_genres.rb
+++ b/db/migrate/20190127232524_add_unique_index_to_game_genres.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToGameGenres < ActiveRecord::Migration[5.2]
+  def change
+    add_index :game_genres, [:game_id, :genre_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_27_225315) do
+ActiveRecord::Schema.define(version: 2019_01_27_232524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,18 +22,21 @@ ActiveRecord::Schema.define(version: 2019_01_27_225315) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "game_genres", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "genre_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id", "genre_id"], name: "index_game_genres_on_game_id_and_genre_id", unique: true
+    t.index ["game_id"], name: "index_game_genres_on_game_id"
+    t.index ["genre_id"], name: "index_game_genres_on_genre_id"
+  end
+
   create_table "games", force: :cascade do |t|
     t.text "name", default: "", null: false
     t.text "description", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "games_genres", id: false, force: :cascade do |t|
-    t.integer "game_id"
-    t.integer "genre_id"
-    t.index ["game_id"], name: "index_games_genres_on_game_id"
-    t.index ["genre_id"], name: "index_games_genres_on_genre_id"
   end
 
   create_table "genres", force: :cascade do |t|
@@ -125,6 +128,8 @@ ActiveRecord::Schema.define(version: 2019_01_27_225315) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "game_genres", "games", on_delete: :cascade
+  add_foreign_key "game_genres", "genres", on_delete: :cascade
   add_foreign_key "release_developers", "companies", on_delete: :cascade
   add_foreign_key "release_developers", "releases", on_delete: :cascade
   add_foreign_key "release_publishers", "companies", on_delete: :cascade

--- a/spec/factories/game_genres.rb
+++ b/spec/factories/game_genres.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :game_genre do
+    game
+    genre
+  end
+end

--- a/spec/models/game_genre_spec.rb
+++ b/spec/models/game_genre_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe GameGenre, type: :model do
+  subject(:game_genre) { FactoryBot.create(:game_genre) }
+
+  describe "Validations" do
+    it "is valid with valid attributes" do
+      expect(game_genre).to be_valid
+    end
+
+    it { should validate_uniqueness_of(:game_id).scoped_to(:genre_id) }
+  end
+
+  describe "Associations" do
+    it { should belong_to(:game) }
+    it { should belong_to(:genre) }
+  end
+end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe Game, type: :model do
   describe "Associations" do
     it { should have_many(:releases) }
     it { should have_many(:platforms) }
-    it { should have_and_belong_to_many(:genres) }
+    it { should have_many(:game_genres) }
   end
 end

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe Genre, type: :model do
   end
 
   describe "Associations" do
-    it { should have_and_belong_to_many(:games) }
+    it { should have_many(:game_genres) }
   end
 end


### PR DESCRIPTION
Drops the games_genres table and replaces it with a has_many :through
relationship rather than a has_and_belongs_to_many relationship.

Also fixes #59.