### PR TITLE
Add Wikidata IDs for companies, engines, games, genres, platforms, and series

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -14,6 +14,14 @@ class Company < ApplicationRecord
   validates :description,
     length: { maximum: 1000 }
 
+  validates :wikidata_id,
+    uniqueness: true,
+    numericality: {
+      only_integer: true,
+      allow_nil: true,
+      greater_than: 0
+    }
+
   pg_search_scope :search,
     against: [:name],
     using: {

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -16,6 +16,7 @@ class Company < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
+    allow_nil: true,
     numericality: {
       only_integer: true,
       allow_nil: true,

--- a/app/models/engine.rb
+++ b/app/models/engine.rb
@@ -10,6 +10,7 @@ class Engine < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
+    allow_nil: true,
     numericality: {
       only_integer: true,
       allow_nil: true,

--- a/app/models/engine.rb
+++ b/app/models/engine.rb
@@ -8,6 +8,14 @@ class Engine < ApplicationRecord
     presence: true,
     length: { maximum: 120 }
 
+  validates :wikidata_id,
+    uniqueness: true,
+    numericality: {
+      only_integer: true,
+      allow_nil: true,
+      greater_than: 0
+    }
+
   pg_search_scope :search,
     against: [:name],
     using: {

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -37,6 +37,7 @@ class Game < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
+    allow_nil: true,
     numericality: {
       only_integer: true,
       allow_nil: true,

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -35,6 +35,14 @@ class Game < ApplicationRecord
     content_type: ['image/png', 'image/jpg', 'image/jpeg'],
     size: { less_than: 4.megabytes }
 
+  validates :wikidata_id,
+    uniqueness: true,
+    numericality: {
+      only_integer: true,
+      allow_nil: true,
+      greater_than: 0
+    }
+
   pg_search_scope :search,
     against: [:name],
     using: {

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -13,6 +13,7 @@ class Genre < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
+    allow_nil: true,
     numericality: {
       only_integer: true,
       allow_nil: true,

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -11,6 +11,14 @@ class Genre < ApplicationRecord
   validates :description,
     length: { maximum: 1000 }
 
+  validates :wikidata_id,
+    uniqueness: true,
+    numericality: {
+      only_integer: true,
+      allow_nil: true,
+      greater_than: 0
+    }
+
   pg_search_scope :search,
     against: [:name],
     using: {

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -13,6 +13,7 @@ class Platform < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
+    allow_nil: true,
     numericality: {
       only_integer: true,
       allow_nil: true,

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -11,6 +11,14 @@ class Platform < ApplicationRecord
   validates :description,
     length: { maximum: 1000 }
 
+  validates :wikidata_id,
+    uniqueness: true,
+    numericality: {
+      only_integer: true,
+      allow_nil: true,
+      greater_than: 0
+    }
+
   pg_search_scope :search,
     against: [:name],
     using: {

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -7,6 +7,14 @@ class Series < ApplicationRecord
     presence: true,
     length: { maximum: 120 }
 
+  validates :wikidata_id,
+    uniqueness: true,
+    numericality: {
+      only_integer: true,
+      allow_nil: true,
+      greater_than: 0
+    }
+
   pg_search_scope :search,
     against: [:name],
     using: {

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -9,6 +9,7 @@ class Series < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
+    allow_nil: true,
     numericality: {
       only_integer: true,
       allow_nil: true,

--- a/db/migrate/20190305020700_add_wikidata_ids_to_genres.rb
+++ b/db/migrate/20190305020700_add_wikidata_ids_to_genres.rb
@@ -1,0 +1,6 @@
+class AddWikidataIdsToGenres < ActiveRecord::Migration[5.2]
+  def change
+    # Use a bigint just in case Wikidata ever has more than 2.1 billion items.
+    add_column :genres, :wikidata_id, :integer, limit: 5
+  end
+end

--- a/db/migrate/20190305020731_add_wikidata_ids_to_platforms.rb
+++ b/db/migrate/20190305020731_add_wikidata_ids_to_platforms.rb
@@ -1,0 +1,6 @@
+class AddWikidataIdsToPlatforms < ActiveRecord::Migration[5.2]
+  def change
+    # Use a bigint just in case Wikidata ever has more than 2.1 billion items.
+    add_column :platforms, :wikidata_id, :integer, limit: 5
+  end
+end

--- a/db/migrate/20190305020739_add_wikidata_ids_to_series.rb
+++ b/db/migrate/20190305020739_add_wikidata_ids_to_series.rb
@@ -1,0 +1,6 @@
+class AddWikidataIdsToSeries < ActiveRecord::Migration[5.2]
+  def change
+    # Use a bigint just in case Wikidata ever has more than 2.1 billion items.
+    add_column :series, :wikidata_id, :integer, limit: 5
+  end
+end

--- a/db/migrate/20190305021512_add_wikidata_ids_to_companies.rb
+++ b/db/migrate/20190305021512_add_wikidata_ids_to_companies.rb
@@ -1,0 +1,6 @@
+class AddWikidataIdsToCompanies < ActiveRecord::Migration[5.2]
+  def change
+    # Use a bigint just in case Wikidata ever has more than 2.1 billion items.
+    add_column :companies, :wikidata_id, :integer, limit: 5
+  end
+end

--- a/db/migrate/20190305021856_add_wikidata_ids_to_games.rb
+++ b/db/migrate/20190305021856_add_wikidata_ids_to_games.rb
@@ -1,0 +1,6 @@
+class AddWikidataIdsToGames < ActiveRecord::Migration[5.2]
+  def change
+    # Use a bigint just in case Wikidata ever has more than 2.1 billion items.
+    add_column :games, :wikidata_id, :integer, limit: 5
+  end
+end

--- a/db/migrate/20190305022847_add_wikidata_ids_to_engines.rb
+++ b/db/migrate/20190305022847_add_wikidata_ids_to_engines.rb
@@ -1,0 +1,6 @@
+class AddWikidataIdsToEngines < ActiveRecord::Migration[5.2]
+  def change
+    # Use a bigint just in case Wikidata ever has more than 2.1 billion items.
+    add_column :engines, :wikidata_id, :integer, limit: 5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_01_023926) do
+ActiveRecord::Schema.define(version: 2019_03_05_022847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,12 +41,14 @@ ActiveRecord::Schema.define(version: 2019_03_01_023926) do
     t.text "description", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "wikidata_id"
   end
 
   create_table "engines", force: :cascade do |t|
     t.text "name", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "wikidata_id"
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|
@@ -126,6 +128,7 @@ ActiveRecord::Schema.define(version: 2019_03_01_023926) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "series_id"
+    t.bigint "wikidata_id"
     t.index ["series_id"], name: "index_games_on_series_id"
   end
 
@@ -134,6 +137,7 @@ ActiveRecord::Schema.define(version: 2019_03_01_023926) do
     t.text "description", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "wikidata_id"
   end
 
   create_table "pg_search_documents", force: :cascade do |t|
@@ -150,12 +154,14 @@ ActiveRecord::Schema.define(version: 2019_03_01_023926) do
     t.text "description", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "wikidata_id"
   end
 
   create_table "series", force: :cascade do |t|
     t.text "name", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "wikidata_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -12,5 +12,13 @@ RSpec.describe Company, type: :model do
 
     it { should validate_length_of(:name).is_at_most(120) }
     it { should validate_length_of(:description).is_at_most(1000) }
+
+    it { should validate_uniqueness_of(:wikidata_id) }
+    it 'validates numericality' do
+      expect(company).to validate_numericality_of(:wikidata_id)
+        .only_integer
+        .allow_nil
+        .is_greater_than(0)
+    end
   end
 end

--- a/spec/models/engine_spec.rb
+++ b/spec/models/engine_spec.rb
@@ -11,5 +11,13 @@ RSpec.describe Engine, type: :model do
     it { should validate_presence_of(:name) }
 
     it { should validate_length_of(:name).is_at_most(120) }
+
+    it { should validate_uniqueness_of(:wikidata_id) }
+    it 'validates numericality' do
+      expect(engine).to validate_numericality_of(:wikidata_id)
+        .only_integer
+        .allow_nil
+        .is_greater_than(0)
+    end
   end
 end

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe Genre, type: :model do
 
     it { should validate_length_of(:name).is_at_most(120) }
     it { should validate_length_of(:description).is_at_most(1000) }
+
+    it { should validate_uniqueness_of(:wikidata_id) }
+    it 'validates numericality' do
+      expect(genre).to validate_numericality_of(:wikidata_id)
+        .only_integer
+        .allow_nil
+        .is_greater_than(0)
+    end
   end
 
   describe "Associations" do

--- a/spec/models/platform_spec.rb
+++ b/spec/models/platform_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe Platform, type: :model do
 
     it { should validate_length_of(:name).is_at_most(120) }
     it { should validate_length_of(:description).is_at_most(1000) }
+
+    it { should validate_uniqueness_of(:wikidata_id) }
+    it 'validates numericality' do
+      expect(platform).to validate_numericality_of(:wikidata_id)
+        .only_integer
+        .allow_nil
+        .is_greater_than(0)
+    end
   end
 
   describe "Associations" do

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe Series, type: :model do
     it { should validate_presence_of(:name) }
 
     it { should validate_length_of(:name).is_at_most(120) }
+
+    it { should validate_uniqueness_of(:wikidata_id) }
+    it 'validates numericality' do
+      expect(series).to validate_numericality_of(:wikidata_id)
+        .only_integer
+        .allow_nil
+        .is_greater_than(0)
+    end
   end
 
   describe "Associations" do


### PR DESCRIPTION
This is currently only implemented as a backend feature, there's no way for users to actually add the IDs themselves and they aren't exposed to the user.

Resolves most of #115.