### PR TITLE
Add Wikidata importer for games

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -967,7 +967,7 @@ Style/NestedTernaryOperator:
   Enabled: true
 
 Style/Next:
-  Enabled: true
+  Enabled: false
 
 Style/NilComparison:
   Enabled: true

--- a/lib/tasks/wikidata_import_games.rake
+++ b/lib/tasks/wikidata_import_games.rake
@@ -7,7 +7,7 @@ namespace :wikidata_import do
     # Abort if there are already records in the database.
     # In the future we may want to be able to re-import from Wikidata,
     # but for now we can just fail for any attempted imports after the first run.
-    # abort("You can't import games if there are already games in the database.") if Game.count > 0
+    abort("You can't import games if there are already games in the database.") if Game.count > 0
 
     puts "Importing games from Wikidata..."
     client = SPARQL::Client.new("https://query.wikidata.org/sparql", method: :get)

--- a/lib/tasks/wikidata_import_games.rake
+++ b/lib/tasks/wikidata_import_games.rake
@@ -39,10 +39,10 @@ namespace :wikidata_import do
 
       puts wikidata_label.inspect
 
-      name = wikidata_label.dig(wikidata_id, 'labels', 'en', 'value')
-      next if name.nil?
+      label = wikidata_label.dig(wikidata_id, 'labels', 'en', 'value')
+      next if label.nil?
 
-      game_hash = { wikidata_id: wikidata_id.delete('Q'), name: name }
+      game_hash = { wikidata_id: wikidata_id.delete('Q'), name: label }
 
       # Create attributes for each property.
       properties.keys.each do |key|
@@ -73,6 +73,7 @@ namespace :wikidata_import do
       keys = []
       game_hash.keys.each do |key|
         next if key == :name || key == :wikidata_id || game_hash[key].nil? || game_hash[key] == []
+
         keys << key
       end
 
@@ -148,10 +149,11 @@ namespace :wikidata_import do
 
       if keys.include?(:series)
         puts 'Adding series.'
-        puts "game_hash[:series]: #{game_hash[:series].inspect}"
 
         series = Series.find_by(wikidata_id: game_hash[:series].first)
         puts series.inspect
+        next if series.nil?
+
         Game.update(
           game.id,
           { series_id: series.id }

--- a/lib/tasks/wikidata_import_games.rake
+++ b/lib/tasks/wikidata_import_games.rake
@@ -37,8 +37,6 @@ namespace :wikidata_import do
         languages: 'en'
       )
 
-      puts wikidata_label.inspect
-
       label = wikidata_label.dig(wikidata_id, 'labels', 'en', 'value')
       next if label.nil?
 
@@ -61,14 +59,10 @@ namespace :wikidata_import do
         game_hash[name].uniq!
       end
 
-      puts game_hash.inspect
-
       game = Game.create!(
         name: game_hash[:name],
         wikidata_id: game_hash[:wikidata_id]
       )
-
-      puts game.inspect
 
       keys = []
       game_hash.keys.each do |key|
@@ -81,7 +75,7 @@ namespace :wikidata_import do
         puts 'Adding developers.'
         game_hash[:developers].each do |developer_id|
           company = Company.find_by(wikidata_id: developer_id)
-          puts company.inspect
+          puts company.inspect if ENV['DEBUG']
           next if company.nil?
 
           GameDeveloper.create!(
@@ -95,7 +89,7 @@ namespace :wikidata_import do
         puts 'Adding publishers.'
         game_hash[:publishers].each do |publisher_id|
           company = Company.find_by(wikidata_id: publisher_id)
-          puts company.inspect
+          puts company.inspect if ENV['DEBUG']
           next if company.nil?
 
           GamePublisher.create!(
@@ -109,7 +103,7 @@ namespace :wikidata_import do
         puts 'Adding platforms.'
         game_hash[:platforms].each do |platform_id|
           platform = Platform.find_by(wikidata_id: platform_id)
-          puts platform.inspect
+          puts platform.inspect if ENV['DEBUG']
           next if platform.nil?
 
           GamePlatform.create!(
@@ -123,7 +117,7 @@ namespace :wikidata_import do
         puts 'Adding engines.'
         game_hash[:engines].each do |engine_id|
           engine = Engine.find_by(wikidata_id: engine_id)
-          puts engine.inspect
+          puts engine.inspect if ENV['DEBUG']
           next if engine.nil?
 
           GameEngine.create!(
@@ -137,7 +131,7 @@ namespace :wikidata_import do
         puts 'Adding genres.'
         game_hash[:genres].each do |genre_id|
           genre = Genre.find_by(wikidata_id: genre_id)
-          puts genre.inspect
+          puts genre.inspect if ENV['DEBUG']
           next if genre.nil?
 
           GameGenre.create!(
@@ -151,7 +145,7 @@ namespace :wikidata_import do
         puts 'Adding series.'
 
         series = Series.find_by(wikidata_id: game_hash[:series].first)
-        puts series.inspect
+        puts series.inspect if ENV['DEBUG']
         next if series.nil?
 
         Game.update(

--- a/lib/tasks/wikidata_import_games.rake
+++ b/lib/tasks/wikidata_import_games.rake
@@ -1,0 +1,66 @@
+namespace :wikidata_import do
+  require 'sparql/client'
+  require 'wikidata_helper'
+
+  desc "Import games from Wikidata"
+  task games: :environment do
+    # Abort if there are already records in the database.
+    # In the future we may want to be able to re-import from Wikidata,
+    # but for now we can just fail for any attempted imports after the first run.
+    abort("You can't import games if there are already games in the database.") if Game.count > 0
+
+    puts "Importing games from Wikidata..."
+    client = SPARQL::Client.new("https://query.wikidata.org/sparql", method: :get)
+
+    rows = []
+    rows.concat(client.query(games_query))
+
+    properties = {
+      developers: 'P178',
+      publishers: 'P123',
+      platforms: 'P400',
+      genres: 'P136',
+      series: 'P179',
+      engines: 'P408'
+    }
+
+    rows.each do |row|
+      url = row.to_h[:item].to_s
+      wikidata_id = url.gsub('http://www.wikidata.org/entity/', '')
+
+      return_value = WikidataHelper.get_claims(
+        entity: wikidata_id
+      )
+
+      game = { wikidata_id: wikidata_id }
+
+      # Create attributes for each property.
+      properties.keys.each do |key|
+        game[key] = []
+      end
+
+      # Fill the game hash's attributes with data from the Wikidata JSON.
+      properties.each do |name, property|
+        next if return_value[property].nil?
+        return_value[property].each do |snak|
+          game[name] << snak.dig('mainsnak', 'datavalue', 'value', 'numeric-id')
+        end
+      end
+
+      puts game.inspect
+      # puts JSON.pretty_generate(return_value)
+    end
+
+    puts "There are now #{Game.count} games in the database."
+  end
+
+  def games_query
+    sparql = <<-SPARQL
+      SELECT ?item WHERE {
+        ?item wdt:P31 wd:Q7889. # Instances of video games.
+      } LIMIT 10
+    SPARQL
+
+    return sparql
+  end
+end


### PR DESCRIPTION
Follow-up to #198, this has the importer create games and their associations with developers, publishers, engines, genres, and platforms, as well as the associated `series_id`. It matches things mostly based on their Wikidata IDs, and the games importer generally requires that the other importers have been run before it for the importer to be useful.

![image](https://user-images.githubusercontent.com/2977353/53783202-eb651980-3ecd-11e9-908e-2553b97cb7a3.png)
