### PR TITLE
Add PCGamingWiki ID to games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## v2019.3.5
 ### Added
 - Add a Rake task to import games from Wikidata. ([#200])
+- Add PCGamingWiki IDs to games and import them with the Wikidata Importer. ([#202])
 
 ## v2019.3.4
 ### Added
@@ -187,3 +188,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#198]: https://github.com/connorshea/ContinueFromCheckpoint/pull/198
 [#199]: https://github.com/connorshea/ContinueFromCheckpoint/pull/199
 [#200]: https://github.com/connorshea/ContinueFromCheckpoint/pull/200
+[#202]: https://github.com/connorshea/ContinueFromCheckpoint/pull/202

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -44,6 +44,15 @@ class Game < ApplicationRecord
       greater_than: 0
     }
 
+  validates :pcgamingwiki_id,
+    uniqueness: true,
+    allow_nil: true,
+    # Validate the format with a simple regex that checks to make sure there
+    # aren't any illegal characters (e.g. <, >, [, ], #, |, etc.)
+    format: /\A[^<>\[\]#\s\\|]+\z/,
+    # Allow up to 300 characters just in case there's some game with an incredibly long name.
+    length: { maximum: 300 }
+
   pg_search_scope :search,
     against: [:name],
     using: {

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -104,13 +104,16 @@
     </ul>
   <% end %>
 
-  <% unless @game.wikidata_id.blank? %>
+  <% unless @game.wikidata_id.blank? && @game.pcgamingwiki_id.blank? %>
     <p class="infobox-header has-text-weight-semibold">External links
     <ul>
-      <li><%= link_to 'Wikidata', "https://www.wikidata.org/wiki/Q#{@game.wikidata_id}"%>
+      <% unless @game.wikidata_id.blank? %>
+        <li><%= link_to 'Wikidata', "https://www.wikidata.org/wiki/Q#{@game.wikidata_id}" %>
+      <% end %>
+      <% unless @game.pcgamingwiki_id.blank? %>
+        <li><%= link_to 'PCGamingWiki', "https://pcgamingwiki.com/wiki/#{@game.pcgamingwiki_id}" %>
+      <% end %>
     </ul>
   <% end %>
-
-  <%# <p class="infobox-header has-text-weight-semibold">External links %>
 </div>
 

--- a/db/migrate/20190306015104_add_pcgw_id_to_games.rb
+++ b/db/migrate/20190306015104_add_pcgw_id_to_games.rb
@@ -1,0 +1,5 @@
+class AddPcgwIdToGames < ActiveRecord::Migration[5.2]
+  def change
+    add_column :games, :pcgamingwiki_id, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_05_022847) do
+ActiveRecord::Schema.define(version: 2019_03_06_015104) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,6 +129,7 @@ ActiveRecord::Schema.define(version: 2019_03_05_022847) do
     t.datetime "updated_at", null: false
     t.bigint "series_id"
     t.bigint "wikidata_id"
+    t.text "pcgamingwiki_id"
     t.index ["series_id"], name: "index_games_on_series_id"
   end
 

--- a/lib/tasks/wikidata_import_games.rake
+++ b/lib/tasks/wikidata_import_games.rake
@@ -59,10 +59,16 @@ namespace :wikidata_import do
         game_hash[name].uniq!
       end
 
-      game = Game.create!(
+      pcgamingwiki_id = wikidata_json.dig('P6337')&.first&.dig('mainsnak', 'datavalue', 'value')
+
+      hash = {
         name: game_hash[:name],
         wikidata_id: game_hash[:wikidata_id]
-      )
+      }
+
+      hash[:pcgamingwiki_id] = pcgamingwiki_id unless pcgamingwiki_id.nil?
+
+      game = Game.create!(hash)
 
       keys = []
       game_hash.keys.each do |key|

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -12,6 +12,39 @@ RSpec.describe Game, type: :model do
 
     it { should validate_length_of(:name).is_at_most(120) }
     it { should validate_length_of(:description).is_at_most(1000) }
+
+    it { should validate_uniqueness_of(:wikidata_id) }
+    it 'validates numericality' do
+      expect(game).to validate_numericality_of(:wikidata_id)
+        .only_integer
+        .allow_nil
+        .is_greater_than(0)
+    end
+
+    it { should validate_uniqueness_of(:pcgamingwiki_id) }
+    it { should validate_length_of(:pcgamingwiki_id).is_at_most(300) }
+
+    it 'allows valid PCGamingWiki IDs' do
+      expect(game).to allow_values(
+        'Battlefront',
+        'Battlefront_II',
+        'Battlefront_II_(2018)',
+        'Star_Wars:_Knights_of_the_Old_Republic_II_-_The_Sith_Lords',
+        '.hack//G.U._Last_Recode'
+      ).for(:pcgamingwiki_id)
+    end
+
+    it 'disallows invalid PCGamingWiki IDs' do
+      expect(game).not_to allow_values(
+        'Invalid[Name',
+        'Invalid]Name',
+        'Invalid\Name',
+        'Invalid Name',
+        'Invalid<Name',
+        'Invalid>Name',
+        'Invalid#Name'
+      ).for(:pcgamingwiki_id)
+    end
   end
 
   describe "Associations" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,19 +18,27 @@ RSpec.describe User, type: :model do
     it { should validate_uniqueness_of(:username) }
 
     # Make sure a bunch of normal usernames work fine
-    it { should allow_value("janedoe").for(:username) }
-    it { should allow_value("john_doe").for(:username) }
-    it { should allow_value("jane.doe").for(:username) }
-    it { should allow_value("janedoe400").for(:username) }
-    it { should allow_value("JohnDoe").for(:username) }
+    it 'allows valid usernames' do
+      expect(user).to allow_values(
+        "janedoe",
+        "john_doe",
+        "jane.doe",
+        "janedoe400",
+        "JohnDoe"
+      ).for(:username)
+    end
 
     # Disallow weird uses of underscores and periods
-    it { should_not allow_value("double__underscore").for(:username) }
-    it { should_not allow_value("_underscore").for(:username) }
-    it { should_not allow_value("underscore_").for(:username) }
-    it { should_not allow_value("double..period").for(:username) }
-    it { should_not allow_value("period.").for(:username) }
-    it { should_not allow_value(".period").for(:username) }
+    it 'disallows invalid usernames' do
+      expect(user).not_to allow_values(
+        "double__underscore",
+        "_underscore",
+        "underscore_",
+        "double..period",
+        "period.",
+        ".period"
+      ).for(:username)
+    end
 
     # Validate uniqueness of email
     it do


### PR DESCRIPTION
This adds a new column for PCGamingWiki IDs, and adds PCGamingWiki IDs to the Wikidata games importer.