### PR TITLE
Add import task for importing game covers from PCGamingWiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v2019.3.7
+### Added
+- Add a Rake task to import game covers from PCGamingWiki. ([#206])
+
 ## v2019.3.5
 ### Added
 - Add a Rake task to import games from Wikidata. ([#200])
@@ -189,3 +193,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#199]: https://github.com/connorshea/ContinueFromCheckpoint/pull/199
 [#200]: https://github.com/connorshea/ContinueFromCheckpoint/pull/200
 [#202]: https://github.com/connorshea/ContinueFromCheckpoint/pull/202
+[#206]: https://github.com/connorshea/ContinueFromCheckpoint/pull/206

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,65 @@
+namespace 'import:pcgamingwiki' do
+  require 'net/http'
+
+  desc "Attach covers to games, only applies to games that have a PCGamingWiki ID and don't already have a cover."
+  task covers: :environment do
+    puts "This task will attach covers to any games which have PCGamingWiki IDs and no cover."
+
+    games = Game.includes(:cover_attachment)
+                .where(active_storage_attachments: { id: nil })
+                .where.not(pcgamingwiki_id: [nil, ""])
+
+    puts "Found #{games.count} games with a PCGamingWiki ID and no cover."
+
+    games.each do |game|
+      puts
+      puts "Adding cover for #{game[:name]}."
+      api_url = "https://pcgamingwiki.com/w/api.php?action=askargs&conditions=#{game[:pcgamingwiki_id].gsub('&', '%26')}&printouts=Cover&format=json"
+
+      begin
+        api_url = URI.parse(api_url)
+      rescue URI::InvalidURIError
+        # I can't get this to work with any other method, so I'm using a
+        # deprecated method here.
+        # rubocop:disable Lint/UriEscapeUnescape
+        api_url = URI.parse(URI.escape(api_url))
+        # rubocop:enable Lint/UriEscapeUnescape
+      end
+
+      req = Net::HTTP::Get.new(api_url)
+      req['Cache-Control'] = 'no-cache'
+
+      res = Net::HTTP.start(api_url.hostname, api_url.port, use_ssl: true) do |http|
+        http.request(req)
+      end
+
+      json = JSON.parse(res.body)
+
+      json = json.dig('query', 'results')
+      puts "Not finding any covers, skipping." if json.nil? || json.blank?
+      next if json.nil? || json.blank?
+
+      # We don't know the key for the game name, so we just use the first key in the hash (generally there's only one key so this should be fine)
+      cover_url = json.dig(json.keys.first, 'printouts', 'Cover').first
+
+      puts "Not finding any covers, skipping." if cover_url.nil?
+      # Exit early if the game has no cover.
+      next if cover_url.nil?
+
+      # The cover URL is returned from the API like //pcgamingwiki.com/images/whatever.png,
+      # so we need to turn it into a valid URL.
+      cover_url = "https:#{cover_url}"
+
+      cover_blob = URI.open(cover_url)
+
+      # Copy the image data to a file with ActiveStorage.
+      game.cover.attach(io: cover_blob, filename: (cover_blob.base_uri.to_s.split('/')[-1]).to_s)
+
+      puts "Cover added to #{game[:name]}."
+    end
+
+    games_with_covers = Game.joins(:cover_attachment)
+    puts
+    puts "Done. #{games_with_covers.count} games now have covers."
+  end
+end

--- a/lib/tasks/wikidata_import.rake
+++ b/lib/tasks/wikidata_import.rake
@@ -1,4 +1,4 @@
-namespace :wikidata_import do
+namespace 'import:wikidata' do
   require 'sparql/client'
   require 'wikidata_helper'
 

--- a/lib/tasks/wikidata_import_games.rake
+++ b/lib/tasks/wikidata_import_games.rake
@@ -1,4 +1,4 @@
-namespace :wikidata_import do
+namespace 'import:wikidata' do
   require 'sparql/client'
   require 'wikidata_helper'
 


### PR DESCRIPTION
This also moves the existing Wikidata import tasks to a shared `import` namespace, so the rake tasks we have now are as follows:

- `rake import:pcgamingwiki:covers`
- `rake import:wikidata:companies`
- `rake import:wikidata:engines`
- `rake import:wikidata:games`
- `rake import:wikidata:genres`
- `rake import:wikidata:platforms`
- `rake import:wikidata:series`